### PR TITLE
Add admin authentication and redesign UI

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,164 +1,612 @@
-/* style.css */
+/* Japanese-inspired minimalist design for Kotak Conference */
 
-/* --- Brand Colors --- */
+/* --- Core Variables --- */
 :root {
     --kotak-red: #c20c2c;
-    --kotak-grey: #f8f9fa;
-    --kotak-grey2: #eaeaea;
-    --kotak-black: #232323;
-    --kotak-dark: #1a1a1a;
+    --kotak-red-light: #e63946;
+    --kotak-red-dark: #a0092a;
+    
+    --neutral-50: #fafafa;
+    --neutral-100: #f5f5f5;
+    --neutral-200: #e5e5e5;
+    --neutral-300: #d4d4d4;
+    --neutral-700: #404040;
+    --neutral-800: #262626;
+    --neutral-900: #171717;
+    
+    --success: #22c55e;
+    --success-light: #dcfce7;
+    --warning: #eab308;
+    --warning-light: #fef3c7;
+    --info: #3b82f6;
+    --info-light: #dbeafe;
+    
+    --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+    --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+    --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+    --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
+    
+    --radius-sm: 6px;
+    --radius-md: 8px;
+    --radius-lg: 12px;
+    --radius-xl: 16px;
+    --radius-2xl: 20px;
+    
+    --spacing-xs: 0.25rem;
+    --spacing-sm: 0.5rem;
+    --spacing-md: 1rem;
+    --spacing-lg: 1.5rem;
+    --spacing-xl: 2rem;
+    --spacing-2xl: 3rem;
 }
 
-/* --- General --- */
+/* --- Reset and Base --- */
+* {
+    box-sizing: border-box;
+}
+
 body {
-    background: var(--kotak-grey);
-    font-family: 'Segoe UI', 'Roboto', Arial, sans-serif;
-    font-size: 1rem;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans', Helvetica, Arial, sans-serif;
+    background: var(--neutral-50);
+    color: var(--neutral-800);
+    line-height: 1.6;
+    font-size: 16px;
+    margin: 0;
+    padding: 0;
+    min-height: 100vh;
 }
 
-h2, .h2 {
+/* --- Typography --- */
+h1, h2, h3, h4, h5, h6 {
+    font-weight: 600;
+    color: var(--neutral-900);
+    letter-spacing: -0.025em;
+    margin: 0 0 var(--spacing-lg) 0;
+}
+
+h2 {
+    font-size: 1.875rem;
     font-weight: 700;
-    color: var(--kotak-dark);
-    margin-bottom: 1.2em;
-    letter-spacing: 0.02em;
 }
 
-@media (min-width: 768px) {
-    h2, .h2 { text-align: left; }
-}
-@media (max-width: 767.98px) {
-    h2, .h2 { text-align: center; font-size: 1.15em; }
+h3 {
+    font-size: 1.5rem;
 }
 
-/* --- Container --- */
+h4 {
+    font-size: 1.25rem;
+}
+
+p {
+    margin: 0 0 var(--spacing-md) 0;
+}
+
+/* --- Layout --- */
 .container {
-    max-width: 1100px;
-    margin: auto;
-    background: transparent;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 var(--spacing-md);
 }
-@media (max-width: 767.98px) {
+
+@media (max-width: 768px) {
     .container {
-        max-width: 100vw;
-        padding-left: 8px;
-        padding-right: 8px;
+        padding: 0 var(--spacing-sm);
     }
 }
 
-/* --- Navbar --- */
+/* --- Navigation --- */
 .navbar {
-    box-shadow: 0 1px 6px rgba(0,0,0,0.06);
-    border-bottom: 2px solid var(--kotak-red);
+    background: white !important;
+    border-bottom: 1px solid var(--neutral-200);
+    box-shadow: var(--shadow-sm);
+    padding: var(--spacing-md) 0;
 }
+
 .navbar-brand {
     color: var(--kotak-red) !important;
     font-weight: 700;
-    letter-spacing: 0.5px;
-    font-size: 1.35em;
-}
-.nav-link {
-    font-weight: 500;
-    font-size: 1.08em;
-    border-radius: 8px;
-    margin: 0 0.12em;
-    transition: background 0.2s, color 0.2s;
-    color: var(--kotak-black) !important;
-    padding: 0.6em 1em;
-}
-.nav-link.active,
-.nav-link:focus,
-.nav-link:hover {
-    background: var(--kotak-red);
-    color: #fff !important;
-}
-@media (max-width: 991.98px) {
-    .navbar .nav-link {
-        font-size: 1.1em;
-        padding: 0.7em 1em;
-        width: 100%;
-        display: block;
-        margin-bottom: 0.35em;
-    }
-    .navbar-nav {
-        align-items: stretch !important;
-    }
+    font-size: 1.5rem;
+    letter-spacing: -0.025em;
 }
 
-/* --- Buttons, Forms, Cards --- */
-.btn, .form-control, .form-label {
-    border-radius: 10px !important;
+.nav-link {
+    color: var(--neutral-700) !important;
+    font-weight: 500;
+    padding: var(--spacing-sm) var(--spacing-md) !important;
+    border-radius: var(--radius-md);
+    transition: all 0.2s ease;
+    margin: 0 var(--spacing-xs);
 }
+
+.nav-link:hover,
+.nav-link.active {
+    background: var(--kotak-red);
+    color: white !important;
+    transform: translateY(-1px);
+}
+
+/* --- Cards --- */
+.card {
+    background: white;
+    border: 1px solid var(--neutral-200);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--shadow-md);
+    overflow: hidden;
+    transition: all 0.3s ease;
+}
+
+.card:hover {
+    box-shadow: var(--shadow-lg);
+    transform: translateY(-2px);
+}
+
+.card-header {
+    background: var(--neutral-100);
+    border-bottom: 1px solid var(--neutral-200);
+    padding: var(--spacing-lg);
+    font-weight: 600;
+    color: var(--neutral-800);
+}
+
+.card-body {
+    padding: var(--spacing-xl);
+}
+
+/* --- Buttons --- */
 .btn {
     font-weight: 600;
+    border-radius: var(--radius-md);
+    padding: var(--spacing-sm) var(--spacing-lg);
+    transition: all 0.2s ease;
+    border: none;
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--spacing-xs);
 }
+
+.btn-primary {
+    background: var(--kotak-red);
+    color: white;
+}
+
+.btn-primary:hover {
+    background: var(--kotak-red-dark);
+    transform: translateY(-1px);
+    box-shadow: var(--shadow-md);
+}
+
+.btn-success {
+    background: var(--success);
+    color: white;
+}
+
+.btn-success:hover {
+    background: #16a34a;
+    transform: translateY(-1px);
+}
+
+.btn-outline-primary {
+    border: 1px solid var(--kotak-red);
+    color: var(--kotak-red);
+    background: transparent;
+}
+
+.btn-outline-primary:hover {
+    background: var(--kotak-red);
+    color: white;
+}
+
+.btn-outline-danger {
+    border: 1px solid var(--kotak-red);
+    color: var(--kotak-red);
+    background: transparent;
+}
+
+.btn-outline-danger:hover {
+    background: var(--kotak-red);
+    color: white;
+}
+
+.btn-warning {
+    background: var(--warning);
+    color: white;
+}
+
+.btn-warning:hover {
+    background: #ca8a04;
+}
+
+/* --- Forms --- */
+.form-control {
+    border: 1px solid var(--neutral-300);
+    border-radius: var(--radius-md);
+    padding: var(--spacing-sm) var(--spacing-md);
+    transition: all 0.2s ease;
+    font-size: 1rem;
+}
+
+.form-control:focus {
+    border-color: var(--kotak-red);
+    box-shadow: 0 0 0 3px rgba(194, 12, 44, 0.1);
+    outline: none;
+}
+
 .form-label {
     font-weight: 600;
+    color: var(--neutral-700);
+    margin-bottom: var(--spacing-xs);
 }
 
-/* --- Table Styling --- */
+/* --- Tables --- */
 .table-responsive {
-    margin-bottom: 2em;
-}
-.table {
-    background: #fff;
-    border-radius: 16px;
+    border-radius: var(--radius-xl);
     overflow: hidden;
-    min-width: 600px;
-}
-.table th, .table td {
-    vertical-align: middle !important;
-    font-size: 1em;
-    word-break: break-word;
-}
-@media (max-width: 767.98px) {
-    .table {
-        min-width: 400px;
-        font-size: 0.95em;
-    }
-}
-.badge-status {
-    font-size: 1em;
-    padding: 0.4em 0.9em;
-    letter-spacing: 0.03em;
-    font-weight: 600;
-    border-radius: 6px;
-}
-.table .badge-status {
-    font-size: 0.96em;
-    padding: 0.35em 0.7em;
+    box-shadow: var(--shadow-md);
 }
 
-/* --- Card --- */
-.card {
-    border-radius: 16px;
-    box-shadow: 0 1px 8px rgba(0,0,0,0.06);
+.table {
+    margin-bottom: 0;
+    background: white;
 }
-.card-header {
-    font-size: 1.12em;
-    font-weight: 700;
-    letter-spacing: 0.03em;
+
+.table th {
+    background: var(--neutral-100);
+    border-bottom: 2px solid var(--neutral-200);
+    font-weight: 600;
+    color: var(--neutral-800);
+    padding: var(--spacing-md);
+}
+
+.table td {
+    padding: var(--spacing-md);
+    border-bottom: 1px solid var(--neutral-200);
+    vertical-align: middle;
+}
+
+.table tbody tr:hover {
+    background: var(--neutral-50);
+}
+
+/* --- Badges --- */
+.badge {
+    font-weight: 500;
+    padding: var(--spacing-xs) var(--spacing-sm);
+    border-radius: var(--radius-sm);
+    font-size: 0.875rem;
+}
+
+.badge-status {
+    padding: var(--spacing-sm) var(--spacing-md);
+    border-radius: var(--radius-md);
+}
+
+.bg-success {
+    background: var(--success) !important;
+}
+
+.bg-warning {
+    background: var(--warning) !important;
+}
+
+.bg-info {
+    background: var(--info) !important;
+}
+
+.bg-danger {
+    background: var(--kotak-red) !important;
+}
+
+.bg-secondary {
+    background: var(--neutral-300) !important;
+    color: var(--neutral-700) !important;
+}
+
+/* --- Alerts --- */
+.alert {
+    border: none;
+    border-radius: var(--radius-lg);
+    padding: var(--spacing-lg);
+    font-weight: 500;
+}
+
+.alert-success {
+    background: var(--success-light);
+    color: #15803d;
+}
+
+.alert-danger {
+    background: #fee2e2;
+    color: #991b1b;
+}
+
+.alert-info {
+    background: var(--info-light);
+    color: #1d4ed8;
+}
+
+.alert-warning {
+    background: var(--warning-light);
+    color: #92400e;
+}
+
+/* --- Admin Login Page --- */
+.admin-login-body {
+    background: linear-gradient(135deg, var(--neutral-100) 0%, var(--neutral-200) 100%);
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--spacing-md);
+}
+
+.admin-login-container {
+    width: 100%;
+    max-width: 400px;
+}
+
+.admin-card {
+    background: white;
+    border-radius: var(--radius-2xl);
+    box-shadow: var(--shadow-xl);
+    padding: var(--spacing-2xl);
+    text-align: center;
+}
+
+.admin-header h2 {
+    color: var(--kotak-red);
+    margin-bottom: var(--spacing-sm);
+    font-size: 1.75rem;
+}
+
+.admin-header p {
+    color: var(--neutral-700);
+    margin-bottom: var(--spacing-xl);
+    font-size: 1rem;
+}
+
+.admin-input {
+    font-size: 1.125rem;
+    padding: var(--spacing-md);
+    margin-bottom: var(--spacing-lg);
+    text-align: center;
+}
+
+.admin-btn {
+    width: 100%;
+    padding: var(--spacing-md);
+    font-size: 1.125rem;
+    background: var(--kotak-red);
+    color: white;
+    margin-bottom: var(--spacing-xl);
+}
+
+.admin-btn:hover {
+    background: var(--kotak-red-dark);
+}
+
+.public-links {
+    border-top: 1px solid var(--neutral-200);
+    padding-top: var(--spacing-lg);
+    margin-top: var(--spacing-lg);
+}
+
+.public-links p {
+    color: var(--neutral-700);
+    font-size: 0.875rem;
+    margin-bottom: var(--spacing-sm);
+}
+
+.public-link {
+    display: block;
+    color: var(--info);
+    text-decoration: none;
+    margin-bottom: var(--spacing-xs);
+    font-size: 0.875rem;
+}
+
+.public-link:hover {
+    text-decoration: underline;
+}
+
+.admin-footer {
+    text-align: center;
+    color: var(--neutral-700);
+    font-size: 0.875rem;
+    margin-top: var(--spacing-xl);
+}
+
+.admin-footer strong {
+    color: var(--kotak-red);
+}
+
+/* --- Admin Dashboard --- */
+.admin-header-section {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: var(--spacing-2xl);
+    padding-bottom: var(--spacing-lg);
+    border-bottom: 1px solid var(--neutral-200);
+}
+
+.logout-btn {
+    font-size: 0.875rem;
+    padding: var(--spacing-xs) var(--spacing-md);
+}
+
+.dashboard-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: var(--spacing-xl);
+    margin-bottom: var(--spacing-2xl);
+}
+
+.dashboard-card {
+    background: white;
+    border-radius: var(--radius-xl);
+    padding: var(--spacing-xl);
+    text-align: center;
+    border: 1px solid var(--neutral-200);
+    transition: all 0.3s ease;
+    box-shadow: var(--shadow-md);
+}
+
+.dashboard-card:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-xl);
+}
+
+.dashboard-card.public-card {
+    border-left: 4px solid var(--info);
+}
+
+.card-icon {
+    font-size: 3rem;
+    margin-bottom: var(--spacing-md);
+    opacity: 0.8;
+}
+
+.dashboard-card h3 {
+    color: var(--neutral-900);
+    margin-bottom: var(--spacing-sm);
+    font-size: 1.25rem;
+}
+
+.dashboard-card p {
+    color: var(--neutral-700);
+    margin-bottom: var(--spacing-lg);
+    font-size: 0.9rem;
+}
+
+.dashboard-btn {
+    width: 100%;
+    padding: var(--spacing-sm) var(--spacing-lg);
+    font-weight: 600;
+}
+
+.admin-info {
+    background: white;
+    border-radius: var(--radius-xl);
+    padding: var(--spacing-xl);
+    border: 1px solid var(--neutral-200);
+    box-shadow: var(--shadow-md);
+}
+
+.admin-info h4 {
+    color: var(--neutral-900);
+    margin-bottom: var(--spacing-lg);
+    font-size: 1.125rem;
+}
+
+.instruction-grid {
+    display: grid;
+    gap: var(--spacing-md);
+}
+
+.instruction-item {
+    padding: var(--spacing-md);
+    background: var(--neutral-50);
+    border-radius: var(--radius-md);
+    border-left: 3px solid var(--kotak-red);
+    font-size: 0.9rem;
+}
+
+.instruction-item strong {
+    color: var(--kotak-red);
+}
+
+/* --- Welcome Page Enhancements --- */
+#qr-reader {
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    box-shadow: var(--shadow-md);
+    border: 2px solid var(--neutral-200);
+}
+
+/* --- Mobile Responsiveness --- */
+@media (max-width: 768px) {
+    .container {
+        padding: 0 var(--spacing-sm);
+    }
+    
+    .admin-header-section {
+        flex-direction: column;
+        gap: var(--spacing-md);
+        text-align: center;
+    }
+    
+    .dashboard-grid {
+        grid-template-columns: 1fr;
+        gap: var(--spacing-lg);
+    }
+    
+    .card-body {
+        padding: var(--spacing-lg);
+    }
+    
+    h2 {
+        font-size: 1.5rem;
+    }
+    
+    .table {
+        font-size: 0.875rem;
+    }
+    
+    .navbar-nav {
+        gap: var(--spacing-xs);
+        margin-top: var(--spacing-md);
+    }
 }
 
 /* --- Footer --- */
 .footer {
-    margin-top: 2em;
-    padding: 1em 0 0.5em 0;
-    background: var(--kotak-grey2);
+    background: white;
+    border-top: 1px solid var(--neutral-200);
+    padding: var(--spacing-xl) 0;
+    margin-top: var(--spacing-2xl);
     text-align: center;
-    font-size: 1em;
-    color: #777;
-    border-top: 2px solid var(--kotak-red);
-    letter-spacing: 0.02em;
-}
-.footer strong {
-    color: var(--kotak-red);
-    font-weight: 700;
+    color: var(--neutral-700);
 }
 
-/* --- Responsive: No X Scroll unless needed --- */
-@media (max-width: 1100px) {
+.footer strong {
+    color: var(--kotak-red);
+}
+
+/* --- Animation Utilities --- */
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.fade-in {
+    animation: fadeIn 0.3s ease-out;
+}
+
+/* --- Focus States for Accessibility --- */
+.btn:focus,
+.form-control:focus,
+.nav-link:focus {
+    outline: 2px solid var(--kotak-red);
+    outline-offset: 2px;
+}
+
+/* --- Print Styles --- */
+@media print {
+    .navbar,
+    .footer,
+    .btn {
+        display: none !important;
+    }
+    
     .container {
-        max-width: 100vw;
-        padding-left: 8px;
-        padding-right: 8px;
+        max-width: none;
+        padding: 0;
+    }
+    
+    .card {
+        box-shadow: none;
+        border: 1px solid #000;
     }
 }

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+{% block title %}Admin Dashboard - Kotak Conference{% endblock %}
+{% block content %}
+<div class="admin-header-section">
+    <h2>Event Management Dashboard</h2>
+    <a href="/admin/logout" class="btn btn-outline-danger btn-sm logout-btn">Logout</a>
+</div>
+
+<div class="dashboard-grid">
+    <div class="dashboard-card">
+        <div class="card-icon">👥</div>
+        <h3>Welcome Desk</h3>
+        <p>Check-in guests and manage plus ones</p>
+        <a href="/welcome" class="btn btn-primary dashboard-btn">Open Welcome</a>
+    </div>
+    
+    <div class="dashboard-card">
+        <div class="card-icon">📊</div>
+        <h3>Guest Analytics</h3>
+        <p>View all registered guests and statistics</p>
+        <a href="/guest_list" class="btn btn-success dashboard-btn">View Analytics</a>
+    </div>
+    
+    <div class="dashboard-card public-card">
+        <div class="card-icon">📝</div>
+        <h3>Registration</h3>
+        <p>Public guest registration page</p>
+        <a href="/register" class="btn btn-outline-primary dashboard-btn" target="_blank">Open Registration</a>
+    </div>
+    
+    <div class="dashboard-card public-card">
+        <div class="card-icon">📱</div>
+        <h3>QR Download</h3>
+        <p>Public QR badge download page</p>
+        <a href="/download_qr" class="btn btn-outline-success dashboard-btn" target="_blank">Open QR Download</a>
+    </div>
+</div>
+
+<div class="admin-info">
+    <h4>Quick Instructions</h4>
+    <div class="instruction-grid">
+        <div class="instruction-item">
+            <strong>Welcome Desk:</strong> Use this on event day for real-time check-ins and guest management
+        </div>
+        <div class="instruction-item">
+            <strong>Guest Analytics:</strong> Monitor registration status, check-ins, and download reports
+        </div>
+        <div class="instruction-item">
+            <strong>Public Pages:</strong> Share registration and QR download links with guests
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin_login.html
+++ b/templates/admin_login.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Admin Login - Kotak Conference</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/static/style.css" rel="stylesheet">
+</head>
+<body class="admin-login-body">
+    <div class="admin-login-container">
+        <div class="admin-card">
+            <div class="admin-header">
+                <h2>Organizer Access</h2>
+                <p>Kotak Conference Management</p>
+            </div>
+            
+            {% if error %}
+                <div class="alert alert-danger">{{ error }}</div>
+            {% endif %}
+            
+            <form method="post" action="/admin">
+                <div class="form-group">
+                    <input type="password" class="form-control admin-input" name="password" placeholder="Enter password" required autofocus>
+                </div>
+                <button type="submit" class="btn admin-btn">Access Dashboard</button>
+            </form>
+            
+            <div class="public-links">
+                <p class="mb-2">Public Access:</p>
+                <a href="/register" class="public-link">Register Guests</a>
+                <a href="/download_qr" class="public-link">Download QR Badge</a>
+            </div>
+        </div>
+    </div>
+    
+    <div class="admin-footer">
+        &copy; {{ year }} Kotak Conference. Made by <strong>Qubix Information Systems</strong>
+    </div>
+</body>
+</html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,24 +19,39 @@
         </button>
         <div class="collapse navbar-collapse justify-content-end" id="navbarMain">
             <ul class="navbar-nav align-items-center mb-2 mb-lg-0 w-100 justify-content-end">
-                <li class="nav-item">
-                    <a class="nav-link{% if request.url.path == '/register' %} active{% endif %}" href="/register">Register</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link{% if request.url.path == '/download_qr' %} active{% endif %}" href="/download_qr">Download QR</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link{% if request.url.path == '/welcome' %} active{% endif %}" href="/welcome">Welcome</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link{% if request.url.path == '/guest_list' %} active{% endif %}" href="/guest_list">Guests List</a>
-                </li>
+                <!-- Check if we're in admin area -->
+                {% if request.url.path.startswith('/admin') or request.url.path in ['/welcome', '/guest_list'] %}
+                    <!-- Admin Navigation -->
+                    <li class="nav-item">
+                        <a class="nav-link{% if request.url.path == '/admin/dashboard' %} active{% endif %}" href="/admin/dashboard">Dashboard</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link{% if request.url.path == '/welcome' %} active{% endif %}" href="/welcome">Welcome Desk</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link{% if request.url.path == '/guest_list' %} active{% endif %}" href="/guest_list">Analytics</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/admin/logout">Logout</a>
+                    </li>
+                {% else %}
+                    <!-- Public Navigation -->
+                    <li class="nav-item">
+                        <a class="nav-link{% if request.url.path == '/register' %} active{% endif %}" href="/register">Register</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link{% if request.url.path == '/download_qr' %} active{% endif %}" href="/download_qr">Download QR</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="/admin">Organizer Login</a>
+                    </li>
+                {% endif %}
             </ul>
         </div>
     </div>
 </nav>
 
-<div class="container py-4">
+<div class="container py-4 fade-in">
     {% block content %}{% endblock %}
 </div>
 
@@ -48,4 +63,3 @@
 {% block script %}{% endblock %}
 </body>
 </html>
-

--- a/templates/download_qr.html
+++ b/templates/download_qr.html
@@ -1,38 +1,110 @@
 {% extends "base.html" %}
-{% block title %}Download Guest QR - Kotak Conference{% endblock %}
+{% block title %}Download QR Badge - Kotak Conference{% endblock %}
 {% block content %}
-<h2 class="text-center mb-4">Download Your Conference QR Badge</h2>
-<form method="post" action="/download_qr" class="mb-3">
-    <label for="identifier" class="form-label">Enter Phone or Guest ID</label>
-    <input type="text" class="form-control mb-2" id="identifier" name="identifier" required>
-    <button type="submit" class="btn btn-success w-100">Get QR Badge</button>
-</form>
-{% if qr_image and guest %}
-    <div class="card shadow-sm mx-auto" style="max-width:330px;">
-        <div class="card-header text-white bg-danger text-center py-2" style="font-size:1.15em;">
-            Welcome to the Kotak Conference
+<div class="row justify-content-center">
+    <div class="col-lg-8 col-md-10">
+        <div class="card">
+            <div class="card-header text-center">
+                <h2 class="mb-2">Download Your QR Badge</h2>
+                <p class="text-muted mb-0">Enter your details to get your conference badge</p>
+            </div>
+            <div class="card-body">
+                <form method="post" action="/download_qr" class="mb-4">
+                    <div class="row">
+                        <div class="col-md-8">
+                            <label for="identifier" class="form-label">Phone Number or Guest ID</label>
+                            <input type="text" class="form-control" id="identifier" name="identifier" required placeholder="Enter your 10-digit phone or guest ID">
+                        </div>
+                        <div class="col-md-4 d-flex align-items-end">
+                            <button type="submit" class="btn btn-success w-100">Get Badge</button>
+                        </div>
+                    </div>
+                </form>
+
+                {% if qr_image and guest %}
+                    <div class="row justify-content-center fade-in">
+                        <div class="col-md-6">
+                            <div class="card border-success">
+                                <div class="card-header bg-success text-white text-center">
+                                    <h5 class="mb-0">🎫 Your Conference Badge</h5>
+                                </div>
+                                <div class="card-body text-center">
+                                    <div class="qr-badge-container">
+                                        <img src="data:image/png;base64,{{ qr_image }}" alt="QR Code" class="img-fluid mb-3" style="max-width: 200px; border: 2px solid var(--neutral-200); border-radius: var(--radius-md);">
+                                    </div>
+                                    
+                                    <div class="guest-details">
+                                        <h4 class="text-success mb-2">{{ guest.name }}</h4>
+                                        <div class="text-muted small mb-1">ID: {{ guest.id }}</div>
+                                        <div class="text-muted small mb-3">Phone: {{ guest.phone }}</div>
+                                        {% if guest.profession %}
+                                            <div class="badge bg-info text-dark mb-3">{{ guest.profession }}</div>
+                                        {% endif %}
+                                    </div>
+                                    
+                                    <div class="d-grid gap-2">
+                                        <a href="data:image/png;base64,{{ qr_image }}" download="kotak_badge_{{ guest.id }}.png" class="btn btn-primary">
+                                            📱 Download Badge
+                                        </a>
+                                        <button onclick="window.print()" class="btn btn-outline-secondary">
+                                            🖨️ Print Badge
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                {% elif error %}
+                    <div class="alert alert-danger text-center fade-in">
+                        <strong>⚠ Not Found:</strong><br>
+                        {{ error }}
+                        <div class="mt-2 small">Please check your phone number or guest ID and try again.</div>
+                    </div>
+                {% endif %}
+            </div>
         </div>
-        <div class="card-body text-center">
-            <img src="data:image/png;base64,{{ qr_image }}" alt="QR Code" class="img-fluid mb-3" style="max-width:150px;">
-            <div class="fw-bold fs-5">{{ guest.name }}</div>
-            <div class="text-muted small">ID: {{ guest.id }}</div>
-            <div class="text-muted small">Phone: {{ guest.phone }}</div>
-            <a href="data:image/png;base64,{{ qr_image }}" download="badge_{{ guest.id }}.png" class="btn btn-outline-primary mt-3 w-100">Download Badge</a>
+        
+        <!-- Instructions Card -->
+        <div class="card mt-4">
+            <div class="card-body">
+                <h5 class="card-title">📱 How to Use Your QR Badge</h5>
+                <div class="instruction-grid">
+                    <div class="instruction-item">
+                        <strong>Download:</strong> Save the badge image to your phone or computer
+                    </div>
+                    <div class="instruction-item">
+                        <strong>Print Option:</strong> Print the badge if you prefer a physical copy
+                    </div>
+                    <div class="instruction-item">
+                        <strong>Event Day:</strong> Show your badge (digital or printed) at the welcome desk
+                    </div>
+                    <div class="instruction-item">
+                        <strong>Quick Entry:</strong> Our team will scan your QR code for instant check-in
+                    </div>
+                </div>
+                
+                <div class="mt-3 p-3 bg-light rounded">
+                    <small class="text-muted">
+                        <strong>Need Help?</strong> If you can't find your registration, please contact our support team or visit the registration desk at the event.
+                    </small>
+                </div>
+            </div>
         </div>
     </div>
-{% elif error %}
-    <div class="alert alert-danger mt-3">{{ error }}</div>
-{% endif %}
-
-<!-- How to Use Block -->
-<div class="alert alert-info mt-5 mb-4 shadow-sm" style="max-width: 600px; margin-left: auto; margin-right: auto;">
-    <h5 class="mb-2"><i class="bi bi-info-circle-fill"></i> How to Use This Page</h5>
-    <ul class="mb-1">
-        <li>Enter your <b>registered phone number</b> or your <b>guest ID</b> above.</li>
-        <li>Click <b>Get QR Badge</b> to display your personalized QR badge.</li>
-        <li>If the badge appears, click <b>Download Badge</b> to save it to your device.</li>
-        <li>Show your badge (on your phone or printout) at the conference entry for seamless check-in.</li>
-    </ul>
-    <div class="small text-muted">If you have issues, please ask the registration desk or contact your event coordinator.</div>
 </div>
+
+<style>
+@media print {
+    .card-header, .btn, .instruction-grid, .navbar, .footer {
+        display: none !important;
+    }
+    .card {
+        border: none !important;
+        box-shadow: none !important;
+    }
+    .qr-badge-container img {
+        max-width: 150px !important;
+    }
+}
+</style>
 {% endblock %}

--- a/templates/guest_list.html
+++ b/templates/guest_list.html
@@ -1,64 +1,176 @@
 {% extends "base.html" %}
-{% block title %}Guests List - Kotak Conference{% endblock %}
+{% block title %}Guest Analytics - Kotak Conference{% endblock %}
 {% block content %}
-<h2>All Guests</h2>
-<div class="mb-3 d-flex flex-wrap align-items-center gap-2">
-    <span class="badge bg-info text-dark">Total: {{ stats.total }}</span>
-    <span class="badge bg-success">Checked In: {{ stats.checked_in }}</span>
-    <span class="badge bg-danger">Not Checked In: {{ stats.not_checked_in }}</span>
-    <span class="badge bg-warning text-dark">Plus Ones: {{ stats.plus_ones }}</span>
-    <a href="/guest_list.csv" class="btn btn-outline-primary btn-sm ms-auto">Download CSV</a>
-</div>
-<div class="table-responsive mb-4">
-    <table class="table table-bordered table-striped align-middle w-100" style="min-width: 700px;">
-        <thead class="table-light">
-            <tr>
-                <th>ID</th>
-                <th>Name</th>
-                <th>Phone</th>
-                <th>Profession</th>
-                <th>Status</th>
-                <th>Plus One</th>
-                <th>Registered At</th>
-            </tr>
-        </thead>
-        <tbody>
-        {% for guest in guests %}
-            <tr>
-                <td>{{ guest.id }}</td>
-                <td>{{ guest.name }}</td>
-                <td>{{ guest.phone }}</td>
-                <td>{{ guest.profession or '' }}</td>
-                <td>
-                    {% if guest.added == "yes" %}
-                        <span class="badge bg-success badge-status">Checked In</span>
-                    {% else %}
-                        <span class="badge bg-secondary badge-status">Not Checked In</span>
-                    {% endif %}
-                </td>
-                <td>
-                    {% if guest.plus_one == "yes" %}
-                        <span class="badge bg-warning text-dark">Added</span>
-                    {% else %}
-                        <span class="badge bg-secondary">No</span>
-                    {% endif %}
-                </td>
-                <td>{{ guest.created }}</td>
-            </tr>
-        {% endfor %}
-        </tbody>
-    </table>
+<div class="admin-header-section">
+    <h2>📊 Guest Analytics & Management</h2>
+    <a href="/guest_list.csv" class="btn btn-outline-primary">
+        📥 Download Report
+    </a>
 </div>
 
-<!-- How to Use Block -->
-<div class="alert alert-info mt-5 mb-4 shadow-sm" style="max-width: 650px; margin-left: auto; margin-right: auto;">
-    <h5 class="mb-2"><i class="bi bi-info-circle-fill"></i> How to Use This Page</h5>
-    <ul class="mb-1">
-        <li><b>Check real-time status</b> of all registered guests, including who has checked in and who has added a plus one.</li>
-        <li>Click <b>Download CSV</b> for an Excel-friendly report of the current list at any time.</li>
-        <li>Green badge = Guest has checked in. Yellow badge = Plus One added.</li>
-        <li>Use the main menu to register new guests or scan for check-in at the Welcome page.</li>
-    </ul>
-    <div class="small text-muted">For help or issues, please contact the registration desk or your event coordinator.</div>
+<!-- Statistics Cards -->
+<div class="row mb-4">
+    <div class="col-6 col-md-3 mb-3">
+        <div class="card text-center">
+            <div class="card-body">
+                <div class="display-6 text-primary mb-2">{{ stats.total }}</div>
+                <div class="small text-muted">Total Registered</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-6 col-md-3 mb-3">
+        <div class="card text-center">
+            <div class="card-body">
+                <div class="display-6 text-success mb-2">{{ stats.checked_in }}</div>
+                <div class="small text-muted">Checked In</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-6 col-md-3 mb-3">
+        <div class="card text-center">
+            <div class="card-body">
+                <div class="display-6 text-danger mb-2">{{ stats.not_checked_in }}</div>
+                <div class="small text-muted">Pending</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-6 col-md-3 mb-3">
+        <div class="card text-center">
+            <div class="card-body">
+                <div class="display-6 text-warning mb-2">{{ stats.plus_ones }}</div>
+                <div class="small text-muted">Plus Ones</div>
+            </div>
+        </div>
+    </div>
 </div>
+
+<!-- Quick Stats Summary -->
+<div class="card mb-4">
+    <div class="card-body">
+        <div class="row text-center">
+            <div class="col-md-4">
+                <div class="progress mb-2" style="height: 8px;">
+                    <div class="progress-bar bg-success" role="progressbar" 
+                         style="width: {% if stats.total > 0 %}{{ (stats.checked_in / stats.total * 100)|round(1) }}{% else %}0{% endif %}%">
+                    </div>
+                </div>
+                <small>Check-in Rate: {% if stats.total > 0 %}{{ (stats.checked_in / stats.total * 100)|round(1) }}%{% else %}0%{% endif %}</small>
+            </div>
+            <div class="col-md-4">
+                <div class="progress mb-2" style="height: 8px;">
+                    <div class="progress-bar bg-warning" role="progressbar" 
+                         style="width: {% if stats.checked_in > 0 %}{{ (stats.plus_ones / stats.checked_in * 100)|round(1) }}{% else %}0{% endif %}%">
+                    </div>
+                </div>
+                <small>Plus One Rate: {% if stats.checked_in > 0 %}{{ (stats.plus_ones / stats.checked_in * 100)|round(1) }}%{% else %}0%{% endif %}</small>
+            </div>
+            <div class="col-md-4">
+                <div class="text-center">
+                    <strong>Total Attendees: {{ stats.checked_in + stats.plus_ones }}</strong>
+                    <div class="small text-muted">(including plus ones)</div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Guest List Table -->
+<div class="card">
+    <div class="card-header">
+        <h5 class="mb-0">All Registered Guests</h5>
+    </div>
+    <div class="card-body p-0">
+        <div class="table-responsive">
+            <table class="table table-hover mb-0">
+                <thead class="table-light">
+                    <tr>
+                        <th>Guest Info</th>
+                        <th>Contact</th>
+                        <th>Profession</th>
+                        <th>Status</th>
+                        <th>Plus One</th>
+                        <th>Registered</th>
+                    </tr>
+                </thead>
+                <tbody>
+                {% for guest in guests %}
+                    <tr>
+                        <td>
+                            <div class="fw-bold">{{ guest.name }}</div>
+                            <div class="small text-muted">ID: {{ guest.id }}</div>
+                        </td>
+                        <td>
+                            <div>📞 {{ guest.phone }}</div>
+                            {% if guest.address %}
+                                <div class="small text-muted">📍 {{ guest.address[:30] }}{% if guest.address|length > 30 %}...{% endif %}</div>
+                            {% endif %}
+                        </td>
+                        <td>
+                            {% if guest.profession %}
+                                <span class="badge bg-light text-dark">{{ guest.profession }}</span>
+                            {% else %}
+                                <span class="text-muted">-</span>
+                            {% endif %}
+                        </td>
+                        <td>
+                            {% if guest.added == "yes" %}
+                                <span class="badge bg-success">✓ Checked In</span>
+                            {% else %}
+                                <span class="badge bg-secondary">⏳ Pending</span>
+                            {% endif %}
+                        </td>
+                        <td>
+                            {% if guest.plus_one == "yes" %}
+                                <span class="badge bg-warning text-dark">👥 Added</span>
+                            {% else %}
+                                <span class="badge bg-light text-muted">-</span>
+                            {% endif %}
+                        </td>
+                        <td>
+                            <div class="small">{{ guest.created[:16] }}</div>
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<!-- Instructions -->
+<div class="card mt-4">
+    <div class="card-body">
+        <h5 class="card-title">📋 Analytics Guide</h5>
+        <div class="instruction-grid">
+            <div class="instruction-item">
+                <strong>Real-time Updates:</strong> This page updates automatically when guests check in at the welcome desk
+            </div>
+            <div class="instruction-item">
+                <strong>Export Data:</strong> Click "Download Report" for an Excel-compatible CSV file with complete guest data
+            </div>
+            <div class="instruction-item">
+                <strong>Status Tracking:</strong> Green badges show checked-in guests, yellow badges show plus ones added
+            </div>
+            <div class="instruction-item">
+                <strong>Quick Access:</strong> Use this page during the event to monitor attendance and identify no-shows
+            </div>
+        </div>
+        
+        <div class="mt-3 p-3 bg-light rounded">
+            <small class="text-muted">
+                <strong>Need Help?</strong> This dashboard provides real-time insights into your event attendance. 
+                Export the data anytime for external analysis or reporting.
+            </small>
+        </div>
+    </div>
+</div>
+
+{% if guests|length == 0 %}
+<div class="text-center py-5">
+    <div class="mb-3" style="font-size: 4rem; opacity: 0.3;">📝</div>
+    <h4>No Guests Registered Yet</h4>
+    <p class="text-muted">Guest registrations will appear here once people start signing up.</p>
+    <a href="/register" class="btn btn-primary" target="_blank">Open Registration Page</a>
+</div>
+{% endif %}
 {% endblock %}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,45 +1,82 @@
 {% extends "base.html" %}
 {% block title %}Register - Kotak Conference{% endblock %}
 {% block content %}
-<h2 class="mb-4 text-center">Register as Guest</h2>
-{% if message %}
-    <div class="alert alert-info text-center">{{ message }}</div>
-{% endif %}
-<form method="post" action="/register" autocomplete="off">
-    <div class="mb-3">
-        <label for="name" class="form-label">Name*</label>
-        <input type="text" class="form-control" id="name" name="name" required maxlength="50">
+<div class="row justify-content-center">
+    <div class="col-lg-6 col-md-8">
+        <div class="card">
+            <div class="card-header text-center">
+                <h2 class="mb-2">Guest Registration</h2>
+                <p class="text-muted mb-0">Join us for the Kotak Conference</p>
+            </div>
+            <div class="card-body">
+                {% if message %}
+                    {% if "successful" in message %}
+                        <div class="alert alert-success text-center fade-in">
+                            <strong>✓ Success!</strong><br>
+                            {{ message }}
+                        </div>
+                    {% else %}
+                        <div class="alert alert-danger text-center fade-in">
+                            <strong>⚠ Error:</strong><br>
+                            {{ message }}
+                        </div>
+                    {% endif %}
+                {% endif %}
+                
+                <form method="post" action="/register" autocomplete="off" class="fade-in">
+                    <div class="mb-4">
+                        <label for="name" class="form-label">Full Name *</label>
+                        <input type="text" class="form-control" id="name" name="name" required maxlength="50" placeholder="Enter your full name">
+                    </div>
+                    
+                    <div class="mb-4">
+                        <label for="phone" class="form-label">Mobile Number *</label>
+                        <input type="tel" class="form-control" id="phone" name="phone" required pattern="[0-9]{10}" placeholder="10-digit mobile number">
+                        <div class="form-text">This will be used for your QR badge</div>
+                    </div>
+                    
+                    <div class="mb-4">
+                        <label for="address" class="form-label">Address *</label>
+                        <input type="text" class="form-control" id="address" name="address" required maxlength="120" placeholder="Your address">
+                    </div>
+                    
+                    <div class="mb-4">
+                        <label for="profession" class="form-label">Profession</label>
+                        <input type="text" class="form-control" id="profession" name="profession" maxlength="50" placeholder="Your profession (optional)">
+                    </div>
+                    
+                    <div class="mb-4">
+                        <label for="notes" class="form-label">Special Requirements</label>
+                        <textarea class="form-control" id="notes" name="notes" maxlength="200" rows="3" placeholder="Any special requirements or notes (optional)"></textarea>
+                    </div>
+                    
+                    <button type="submit" class="btn btn-primary w-100 py-3">
+                        <span class="fw-bold">Register for Conference</span>
+                    </button>
+                </form>
+            </div>
+        </div>
+        
+        <!-- Instructions Card -->
+        <div class="card mt-4">
+            <div class="card-body">
+                <h5 class="card-title">📋 Registration Guide</h5>
+                <div class="instruction-grid">
+                    <div class="instruction-item">
+                        <strong>Step 1:</strong> Fill out all required fields accurately
+                    </div>
+                    <div class="instruction-item">
+                        <strong>Step 2:</strong> Ensure your mobile number is correct - it's used for your QR badge
+                    </div>
+                    <div class="instruction-item">
+                        <strong>Step 3:</strong> After registration, download your QR badge from the next page
+                    </div>
+                    <div class="instruction-item">
+                        <strong>Event Day:</strong> Bring your QR badge (digital or printed) for quick check-in
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
-    <div class="mb-3">
-        <label for="phone" class="form-label">Phone*</label>
-        <input type="tel" class="form-control" id="phone" name="phone" required pattern="[0-9]{10}">
-        <div class="form-text">Enter 10-digit mobile number</div>
-    </div>
-    <div class="mb-3">
-        <label for="address" class="form-label">Address*</label>
-        <input type="text" class="form-control" id="address" name="address" required maxlength="120">
-    </div>
-    <div class="mb-3">
-        <label for="profession" class="form-label">Profession</label>
-        <input type="text" class="form-control" id="profession" name="profession" maxlength="50">
-    </div>
-    <div class="mb-3">
-        <label for="notes" class="form-label">Notes</label>
-        <textarea class="form-control" id="notes" name="notes" maxlength="200"></textarea>
-    </div>
-    <button type="submit" class="btn btn-primary w-100">Register</button>
-</form>
-
-<!-- How to Use Block -->
-<div class="alert alert-info mt-5 mb-4 shadow-sm" style="max-width: 600px; margin-left: auto; margin-right: auto;">
-    <h5 class="mb-2"><i class="bi bi-person-plus-fill"></i> How to Use This Registration Page</h5>
-    <ul class="mb-1">
-        <li><b>For Volunteers:</b> Stand in front of the guest and fill out the form with their details. Always confirm the correct spelling of names and mobile number.</li>
-        <li>Make sure the <b>phone number</b> is a valid 10-digit mobile. This will be used for generating the QR badge.</li>
-        <li><b>Address</b> and <b>Profession</b> help us personalize the experience. “Notes” can be used for any special requirements or comments.</li>
-        <li>Once you click <b>Register</b>, the system generates a unique ID and QR badge for the guest, available on the next step.</li>
-        <li><b>For Self-Registration:</b> Guests may fill the form themselves if comfortable. Volunteers should be available for any help or questions.</li>
-    </ul>
-    <div class="small text-muted">Need help? Please call the event helpdesk or ask a coordinator nearby.</div>
 </div>
 {% endblock %}

--- a/templates/welcome.html
+++ b/templates/welcome.html
@@ -1,85 +1,176 @@
 {% extends "base.html" %}
-{% block title %}Welcome - Kotak Conference{% endblock %}
+{% block title %}Welcome Desk - Kotak Conference{% endblock %}
 
 {% block head %}
 <script src="/static/html5-qrcode.min.js"></script>
 {% endblock %}
 
 {% block content %}
-<h2 class="text-center mb-3">Welcome to the Conference</h2>
-<form method="post" action="/welcome" id="welcome-form" autocomplete="off">
-    <div class="mb-3">
-        <label for="lookup" class="form-label">Enter Phone, Guest ID, or Scan QR</label>
-        <input type="text" class="form-control" id="lookup" name="lookup" required autofocus>
+<div class="row justify-content-center">
+    <div class="col-lg-8 col-md-10">
+        <div class="card">
+            <div class="card-header text-center">
+                <h2 class="mb-2">🎉 Welcome to Kotak Conference</h2>
+                <p class="text-muted mb-0">Event Day Check-In</p>
+            </div>
+            <div class="card-body">
+                <form method="post" action="/welcome" id="welcome-form" autocomplete="off">
+                    <div class="row mb-3">
+                        <div class="col-md-8">
+                            <label for="lookup" class="form-label">Phone Number, Guest ID, or Scan QR</label>
+                            <input type="text" class="form-control" id="lookup" name="lookup" required autofocus placeholder="Enter phone/ID or scan QR code">
+                        </div>
+                        <div class="col-md-4 d-flex align-items-end gap-2">
+                            <button type="submit" class="btn btn-primary flex-fill">Check In</button>
+                        </div>
+                    </div>
+                    
+                    <div class="d-grid gap-2">
+                        <button type="button" class="btn btn-success" id="scan-btn">
+                            📸 Scan QR Code
+                        </button>
+                    </div>
+                </form>
+
+                <!-- QR Scanner Area -->
+                <div id="qr-reader" style="display:none;" class="mt-3"></div>
+                
+                {% if guest %}
+                    <div class="alert alert-success mt-4 text-center fade-in">
+                        <div class="row align-items-center">
+                            <div class="col-md-8">
+                                <h4 class="mb-2">🎊 Welcome, {{ guest.name }}!</h4>
+                                {% if guest.profession %}
+                                    <div class="mb-2">
+                                        <span class="badge bg-info text-dark">{{ guest.profession }}</span>
+                                    </div>
+                                {% endif %}
+                                <div class="small text-muted">
+                                    ID: {{ guest.id }} | Phone: {{ guest.phone }}
+                                </div>
+                                
+                                <div class="mt-3">
+                                    <span class="badge bg-success fs-6 px-3 py-2">✓ Checked In Successfully</span>
+                                </div>
+                                
+                                {% if already_checked_in %}
+                                    <div class="mt-2 small text-info">
+                                        Previously checked in - Welcome back!
+                                    </div>
+                                {% endif %}
+                            </div>
+                            
+                            <div class="col-md-4">
+                                {% if guest.plus_one == "no" %}
+                                    <button type="button" class="btn btn-warning" onclick="showPlusOneModal()">
+                                        👥 Add Plus One
+                                    </button>
+                                {% else %}
+                                    <div class="text-center">
+                                        <span class="badge bg-warning text-dark fs-6 px-3 py-2">Plus One Added</span>
+                                    </div>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
+                {% elif error %}
+                    <div class="alert alert-danger mt-4 text-center fade-in">
+                        <strong>⚠ {{ error }}</strong>
+                        <div class="mt-2 small">Please verify the phone number or guest ID and try again.</div>
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+        
+        <!-- Quick Stats Card -->
+        <div class="card mt-4">
+            <div class="card-body">
+                <h5 class="card-title">📊 Quick Actions</h5>
+                <div class="row text-center">
+                    <div class="col-6 col-md-3 mb-3">
+                        <a href="/guest_list" class="btn btn-outline-primary w-100">
+                            <div class="small">View</div>
+                            <strong>Analytics</strong>
+                        </a>
+                    </div>
+                    <div class="col-6 col-md-3 mb-3">
+                        <a href="/register" class="btn btn-outline-success w-100" target="_blank">
+                            <div class="small">New</div>
+                            <strong>Registration</strong>
+                        </a>
+                    </div>
+                    <div class="col-6 col-md-3 mb-3">
+                        <button class="btn btn-outline-info w-100" onclick="showScanHelp()">
+                            <div class="small">Scan</div>
+                            <strong>Help</strong>
+                        </button>
+                    </div>
+                    <div class="col-6 col-md-3 mb-3">
+                        <button class="btn btn-outline-secondary w-100" onclick="document.getElementById('lookup').value=''; document.getElementById('lookup').focus();">
+                            <div class="small">Clear &</div>
+                            <strong>Reset</strong>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
-    <button type="submit" class="btn btn-primary w-100 mb-2">Enter</button>
-    <button type="button" class="btn btn-success w-100 mb-2" id="scan-btn" type="button">Scan QR Code</button>
-</form>
+</div>
 
-<!-- QR Scanner Area (hidden by default) -->
-<div id="qr-reader" style="width:320px;max-width:100%;margin:auto;display:none;"></div>
-
-<!-- Instructions Modal -->
+<!-- Scan Help Modal -->
 <div class="modal fade" id="scanHelpModal" tabindex="-1" aria-labelledby="scanHelpLabel" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title" id="scanHelpLabel">How to Scan QR Code</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-      </div>
-      <div class="modal-body">
-        <ul>
-          <li>Tap <b>Scan QR Code</b> and allow camera access when prompted.</li>
-          <li>Point your camera steadily at the badge QR code.</li>
-          <li>On successful scan, your entry will be auto-checked-in instantly.</li>
-          <li>Each guest can enter once. To add a <b>Plus One</b>, see the option after check-in.</li>
-        </ul>
-      </div>
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="scanHelpLabel">📸 QR Code Scanner Guide</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="instruction-grid">
+                    <div class="instruction-item">
+                        <strong>Step 1:</strong> Click "Scan QR Code" button above
+                    </div>
+                    <div class="instruction-item">
+                        <strong>Step 2:</strong> Allow camera access when prompted by your browser
+                    </div>
+                    <div class="instruction-item">
+                        <strong>Step 3:</strong> Point camera steadily at guest's QR badge
+                    </div>
+                    <div class="instruction-item">
+                        <strong>Step 4:</strong> Scanner will automatically check them in when detected
+                    </div>
+                </div>
+                <div class="mt-3 p-3 bg-light rounded">
+                    <small><strong>Tip:</strong> Ensure good lighting and hold the badge steady for best results.</small>
+                </div>
+            </div>
+        </div>
     </div>
-  </div>
 </div>
 
-<!-- Plus One Modal (shows after check-in, optional) -->
+<!-- Plus One Modal -->
 <div class="modal fade" id="plusOneModal" tabindex="-1" aria-labelledby="plusOneModalLabel" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title" id="plusOneModalLabel">Add Plus One</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-      </div>
-      <div class="modal-body text-center">
-        <form method="post" action="/add_plus_one">
-            <input type="hidden" name="lookup" value="{{ guest.id if guest }}">
-            <button type="submit" class="btn btn-warning">Confirm Add Plus One</button>
-        </form>
-      </div>
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="plusOneModalLabel">👥 Add Plus One</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body text-center">
+                <p>Would you like to add a plus one for <strong>{{ guest.name if guest else '' }}</strong>?</p>
+                <form method="post" action="/add_plus_one">
+                    <input type="hidden" name="lookup" value="{{ guest.id if guest }}">
+                    <div class="d-grid gap-2">
+                        <button type="submit" class="btn btn-warning">✓ Confirm Add Plus One</button>
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    </div>
+                </form>
+            </div>
+        </div>
     </div>
-  </div>
 </div>
+{% endblock %}
 
-{% if guest %}
-    <div class="alert alert-success mt-3 text-center">
-        <b>Welcome, {{ guest.name }}!</b><br>
-        Profession: {{ guest.profession or 'N/A' }}<br>
-        ID: {{ guest.id }}<br>
-        <span class="badge bg-success mt-2">Checked In</span>
-        {% if already_checked_in %}
-            <div class="text-info mt-2">Already checked in!</div>
-        {% endif %}
-        {% if guest.plus_one == "no" %}
-            <!-- Show Plus One button as inline or modal trigger -->
-            <button type="button" class="btn btn-warning mt-3" onclick="showPlusOneModal();">Add Plus One</button>
-        {% else %}
-            <div class="text-info mt-2">Plus One Already Added</div>
-        {% endif %}
-    </div>
-{% elif error %}
-    <div class="alert alert-danger mt-3 text-center">{{ error }}</div>
-{% endif %}
-
-<div class="text-center mt-4">
-    <a href="#" id="scan-help-link" class="small text-decoration-underline">How to use QR Scan?</a>
-</div>
 {% endblock %}
 
 {% block script %}
@@ -88,43 +179,90 @@ function showScanHelp() {
     var modal = new bootstrap.Modal(document.getElementById('scanHelpModal'));
     modal.show();
 }
+
 function showPlusOneModal() {
     var modal = new bootstrap.Modal(document.getElementById('plusOneModal'));
     modal.show();
 }
+
 document.addEventListener("DOMContentLoaded", function() {
-    document.getElementById("scan-help-link").onclick = function(e) {
-        e.preventDefault();
-        showScanHelp();
-    };
     let qrReaderObj = null;
+    let isScanning = false;
+    
     document.getElementById('scan-btn').onclick = function() {
-        document.getElementById('qr-reader').style.display = '';
-        if (qrReaderObj) {
-            qrReaderObj.stop().then(() => startQrScanner());
+        if (isScanning) {
+            stopScanner();
         } else {
-            startQrScanner();
+            startScanner();
         }
     };
-    function startQrScanner() {
+    
+    function startScanner() {
+        document.getElementById('qr-reader').style.display = 'block';
+        document.getElementById('scan-btn').textContent = '⏹️ Stop Scanning';
+        document.getElementById('scan-btn').classList.remove('btn-success');
+        document.getElementById('scan-btn').classList.add('btn-danger');
+        isScanning = true;
+        
         qrReaderObj = new Html5Qrcode("qr-reader");
         qrReaderObj.start(
             { facingMode: "environment" },
-            { fps: 10, qrbox: { width: 250, height: 250 } },
+            { 
+                fps: 10, 
+                qrbox: { width: 250, height: 250 },
+                aspectRatio: 1.0
+            },
             qrCodeMessage => {
                 document.getElementById('lookup').value = qrCodeMessage;
-                qrReaderObj.stop().then(() => {
-                    document.getElementById('qr-reader').style.display = 'none';
-                    document.getElementById('welcome-form').submit();
-                });
+                stopScanner();
+                document.getElementById('welcome-form').submit();
             },
-            errorMessage => {}
-        );
+            errorMessage => {
+                // Ignore scan errors - they're frequent and normal
+            }
+        ).catch(err => {
+            console.error("Scanner error:", err);
+            alert("Camera access denied or not available. Please check permissions.");
+            stopScanner();
+        });
     }
-    // Optionally show the plus one modal automatically after check-in:
-    {% if guest and guest.plus_one == "no" and not error %}
-        showPlusOneModal();
+    
+    function stopScanner() {
+        if (qrReaderObj) {
+            qrReaderObj.stop().then(() => {
+                qrReaderObj.clear();
+                qrReaderObj = null;
+            }).catch(err => {
+                console.error("Error stopping scanner:", err);
+            });
+        }
+        document.getElementById('qr-reader').style.display = 'none';
+        document.getElementById('scan-btn').textContent = '📸 Scan QR Code';
+        document.getElementById('scan-btn').classList.remove('btn-danger');
+        document.getElementById('scan-btn').classList.add('btn-success');
+        isScanning = false;
+    }
+    
+    // Auto-show plus one modal if applicable
+    {% if guest and guest.plus_one == "no" and not error and not already_checked_in %}
+        setTimeout(() => {
+            showPlusOneModal();
+        }, 1500);
     {% endif %}
+    
+    // Auto-focus on input when page loads
+    document.getElementById('lookup').focus();
+    
+    // Clear input on Escape key
+    document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') {
+            document.getElementById('lookup').value = '';
+            document.getElementById('lookup').focus();
+            if (isScanning) {
+                stopScanner();
+            }
+        }
+    });
 });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- overhaul `main.py` with cookie-based admin authentication
- add admin login and dashboard templates
- update base template navigation logic
- refine registration, QR download, welcome, and analytics pages
- apply minimalist Japanese-inspired styling

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_685d39b4f5f8832c9c0acee61e2de572