### PR TITLE
Fix welcome auth errors and footer layout

### DIFF
--- a/templates/admin_login.html
+++ b/templates/admin_login.html
@@ -11,6 +11,7 @@
             background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
             min-height: 100vh;
             display: flex;
+            flex-direction: column;
             align-items: center;
             justify-content: center;
             padding: 1rem;
@@ -39,6 +40,10 @@
             max-width: 420px;
             position: relative;
             z-index: 10;
+            flex: 1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
         }
         
         .admin-card {
@@ -46,7 +51,7 @@
             backdrop-filter: blur(10px);
             border: 1px solid rgba(255, 255, 255, 0.2);
             border-radius: 24px;
-            box-shadow: 
+            box-shadow:
                 0 20px 25px -5px rgba(0, 0, 0, 0.1),
                 0 10px 10px -5px rgba(0, 0, 0, 0.04),
                 0 0 0 1px rgba(255, 255, 255, 0.5);
@@ -54,6 +59,7 @@
             text-align: center;
             transform: translateY(0);
             transition: all 0.3s ease;
+            width: 100%;
         }
         
         .admin-card:hover {
@@ -208,11 +214,15 @@
         }
         
         .admin-footer {
+            position: relative;
+            z-index: 10;
             text-align: center;
             color: #64748b;
             font-size: 0.875rem;
-            margin-top: 2rem;
             font-weight: 500;
+            padding: 1rem;
+            margin-top: auto;
+            width: 100%;
         }
         
         .admin-footer strong {


### PR DESCRIPTION
## Summary
- add try/except blocks for welcome and admin routes
- remove conflicting `response_class` usage on protected routes
- improve global exception handler
- adjust admin login page layout so footer sits at the bottom

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_685d41f6d858832cbab23c2fe8b95ae0